### PR TITLE
Disable JarHell with class loading override

### DIFF
--- a/src/test/java/org/opensearch/bootstrap/JarHell.java
+++ b/src/test/java/org/opensearch/bootstrap/JarHell.java
@@ -1,0 +1,21 @@
+package org.opensearch.bootstrap;
+
+import java.io.IOException;
+import java.net.URISyntaxException;
+import java.net.URL;
+import java.util.function.Consumer;
+import java.util.HashSet;
+import java.util.Set;
+
+/**
+ * Disable JarHell to unblock test development
+ * https://github.com/opensearch-project/security/issues/1938
+ */
+public class JarHell {
+    private JarHell() {}
+    public static void checkJarHell(Consumer<String> output) throws IOException, Exception {}
+    public static void checkJarHell(Set<URL> urls, Consumer<String> output) throws URISyntaxException, IOException {}
+    public static void checkVersionFormat(String targetVersion) {}
+    public static void checkJavaVersion(String resource, String targetVersion) {}
+    public static Set<URL> parseClassPath() {return new HashSet<URL>();}
+}


### PR DESCRIPTION
### Description
Disable JarHell with class loading override

### Testing
Ran locally, the test was able to execute without any jar hell errors

### Check List
- [ ] New functionality includes testing
- [ ] New functionality has been documented
- [X] Commits are signed per the DCO using --signoff

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
