### PR TITLE
DLS pre-filter scoring: keep relevance scores within the visible subset (opt-in)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1043,6 +1043,8 @@ run {
         node.setting("plugins.security.check_snapshot_restore_write_privileges", "true")
         node.setting("plugins.security.restapi.roles_enabled", "[\"all_access\", \"security_rest_api_access\"]")
         node.setting("plugins.security.system_indices.enabled", "true")
+        node.setting("plugins.security.dls.mode", "adaptive")
+        node.setting("plugins.security.dls.pre_filter_scoring", "true")
 
         var creds = node.getCredentials()
         if (creds.isEmpty()) {

--- a/src/integrationTest/java/org/opensearch/security/DlsPreFilterScoringIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/DlsPreFilterScoringIntegrationTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchType;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
@@ -111,7 +112,14 @@ public class DlsPreFilterScoringIntegrationTest {
     }
 
     private SearchResponse searchAs(RestHighLevelClient client, String matchTerm) throws IOException {
+        return searchAs(client, matchTerm, null);
+    }
+
+    private SearchResponse searchAs(RestHighLevelClient client, String matchTerm, SearchType searchType) throws IOException {
         SearchRequest request = new SearchRequest(INDEX);
+        if (searchType != null) {
+            request.searchType(searchType);
+        }
         SearchSourceBuilder source = new SearchSourceBuilder().size(20);
         if (matchTerm != null) {
             source.query(QueryBuilders.matchQuery(CONTENT_FIELD, matchTerm));
@@ -157,6 +165,34 @@ public class DlsPreFilterScoringIntegrationTest {
             // (plain post-filter DLS) restrictedScore would be measurably below absentScore.
             assertThat(
                 "restricted-term score must equal absent-term score under pre-filter scoring",
+                (double) restrictedScore,
+                closeTo(absentScore, 0.0001)
+            );
+        }
+    }
+
+    /**
+     * dfs_query_then_fetch gathers term statistics in a separate DFS phase before the query phase.
+     * The pre-filter wrap is applied in the query phase (onPreQueryPhase -&gt; handleSearchContext), so
+     * this asserts the DFS phase also sees the wrapped query and does not reintroduce whole-shard
+     * statistics: under DFS, a term confined to non-visible docs must still score the same as an
+     * absent term. Guards the (otherwise only hand-verified) DFS coverage.
+     */
+    @Test
+    public void scoresAreVisibilityIndependent_underDfsQueryThenFetch() throws IOException {
+        try (RestHighLevelClient client = cluster.getRestHighLevelClient(CARDIO_USER)) {
+            SearchResponse restrictedResp = searchAs(client, RESTRICTED_TERM, SearchType.DFS_QUERY_THEN_FETCH);
+            SearchHit[] restrictedHits = restrictedResp.getHits().getHits();
+            assertThat((double) restrictedHits.length, greaterThan(0.0));
+            float restrictedScore = restrictedHits[0].getScore();
+
+            SearchResponse absentResp = searchAs(client, ABSENT_TERM, SearchType.DFS_QUERY_THEN_FETCH);
+            SearchHit[] absentHits = absentResp.getHits().getHits();
+            assertThat((double) absentHits.length, greaterThan(0.0));
+            float absentScore = absentHits[0].getScore();
+
+            assertThat(
+                "under dfs_query_then_fetch, restricted-term score must equal absent-term score",
                 (double) restrictedScore,
                 closeTo(absentScore, 0.0001)
             );

--- a/src/integrationTest/java/org/opensearch/security/DlsPreFilterScoringIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/DlsPreFilterScoringIntegrationTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.security;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.transport.client.Client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.opensearch.client.RequestOptions.DEFAULT;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
+import static org.opensearch.test.framework.matcher.SearchResponseMatchers.isSuccessfulSearchResponse;
+import static org.opensearch.test.framework.matcher.SearchResponseMatchers.numberOfTotalHitsIsEqualTo;
+
+/**
+ * Verifies the DLS pre-filter scoring bridge (plugins.security.dls.pre_filter_scoring).
+ * <p>
+ * When enabled, filter-level DLS wraps its (DLS filter + user query) in a constant_score, so BM25
+ * statistics reflect only the documents the role can read. This test asserts the two properties that
+ * matter:
+ * <ul>
+ *   <li><b>Isolation is unchanged</b> — the restricted user still gets exactly their subset of
+ *       documents (the bridge changes scoring, not which docs are returned), and cannot see the rest.</li>
+ *   <li><b>Scores are visibility-independent</b> — a term that occurs only in documents the user cannot
+ *       read no longer affects the score of a document the user can read. Under constant_score every
+ *       visible hit scores 1.0, so relevance scores depend only on the visible subset.</li>
+ * </ul>
+ */
+public class DlsPreFilterScoringIntegrationTest {
+
+    private static final String INDEX = "documents";
+    private static final String DEPT_FIELD = "dept";
+    private static final String CONTENT_FIELD = "content";
+    private static final String VISIBLE_DEPT = "cardiology";
+    private static final String RESTRICTED_DEPT = "oncology";
+    // Appears only in restricted documents -> inflates its corpus-wide df.
+    private static final String RESTRICTED_TERM = "infarction";
+    // Appears in no document at all.
+    private static final String ABSENT_TERM = "zzqxkjpwvbm";
+
+    static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
+
+    // Restricted to cardiology via a DLS clause on the role — this is the "secured view" binding.
+    static final TestSecurityConfig.User CARDIO_USER = new TestSecurityConfig.User("cardio_user").roles(
+        new TestSecurityConfig.Role("cardiology_only").clusterPermissions("cluster_composite_ops_ro")
+            .indexPermissions("read")
+            .dls(String.format("{\"term\":{\"%s\":\"%s\"}}", DEPT_FIELD, VISIBLE_DEPT))
+            .on(INDEX)
+    );
+
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .anonymousAuth(false)
+        // Turn ON the pre-filter scoring bridge, and force filter-level DLS so the bridge's
+        // constant_score wrap is exercised. (In ADAPTIVE mode a simple term DLS query would take the
+        // lucene-level reader path instead; the pre-filter bridge currently covers the filter-level
+        // path — closing the lucene-level path's scoring is the follow-up that reuses the core
+        // pre_filter filtered-statistics work.)
+        .nodeSettings(Map.of("plugins.security.dls.pre_filter_scoring", true, "plugins.security.dls.mode", "filter_level"))
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(ADMIN_USER, CARDIO_USER)
+        .build();
+
+    @BeforeClass
+    public static void createTestData() {
+        try (Client client = cluster.getInternalNodeClient()) {
+            // 3 visible cardiology docs (none carry the restricted term themselves)...
+            for (int i = 0; i < 3; i++) {
+                client.prepareIndex(INDEX)
+                    .setRefreshPolicy(IMMEDIATE)
+                    .setSource(DEPT_FIELD, VISIBLE_DEPT, CONTENT_FIELD, "cardiology note " + i)
+                    .get();
+            }
+            // ...many restricted docs carrying the restricted term -> high corpus-wide df...
+            for (int i = 0; i < 50; i++) {
+                client.prepareIndex(INDEX)
+                    .setRefreshPolicy(IMMEDIATE)
+                    .setSource(DEPT_FIELD, RESTRICTED_DEPT, CONTENT_FIELD, "restricted " + RESTRICTED_TERM + " " + i)
+                    .get();
+            }
+            // ...and one visible probe doc containing BOTH the restricted term and the absent term.
+            client.prepareIndex(INDEX)
+                .setRefreshPolicy(IMMEDIATE)
+                .setSource(DEPT_FIELD, VISIBLE_DEPT, CONTENT_FIELD, "probe " + RESTRICTED_TERM + " " + ABSENT_TERM)
+                .get();
+        }
+    }
+
+    private SearchResponse searchAs(RestHighLevelClient client, String matchTerm) throws IOException {
+        SearchRequest request = new SearchRequest(INDEX);
+        SearchSourceBuilder source = new SearchSourceBuilder().size(20);
+        if (matchTerm != null) {
+            source.query(QueryBuilders.matchQuery(CONTENT_FIELD, matchTerm));
+        } else {
+            source.query(QueryBuilders.matchAllQuery());
+        }
+        request.source(source);
+        return client.search(request, DEFAULT);
+    }
+
+    @Test
+    public void isolationIsPreserved_userSeesOnlyCardiology() throws IOException {
+        try (RestHighLevelClient client = cluster.getRestHighLevelClient(CARDIO_USER)) {
+            // 4 cardiology docs total (3 notes + 1 probe); the 50 restricted docs must be invisible.
+            SearchResponse all = searchAs(client, null);
+            assertThat(all, isSuccessfulSearchResponse());
+            assertThat(all, numberOfTotalHitsIsEqualTo(4));
+
+            // The restricted term is confined to non-visible docs, so the only hit is the visible sample doc.
+            SearchResponse forRestricted = searchAs(client, RESTRICTED_TERM);
+            assertThat(forRestricted, isSuccessfulSearchResponse());
+            assertThat(forRestricted, numberOfTotalHitsIsEqualTo(1));
+        }
+    }
+
+    @Test
+    public void scoresAreVisibilityIndependent_underPreFilterScoring() throws IOException {
+        try (RestHighLevelClient client = cluster.getRestHighLevelClient(CARDIO_USER)) {
+            // Sample scored for the restricted term (present in 50 non-visible docs)...
+            SearchResponse restrictedResp = searchAs(client, RESTRICTED_TERM);
+            SearchHit[] restrictedHits = restrictedResp.getHits().getHits();
+            assertThat((double) restrictedHits.length, greaterThan(0.0));
+            float restrictedScore = restrictedHits[0].getScore();
+
+            // ...vs the same probe scored for the absent term (present nowhere).
+            SearchResponse absentResp = searchAs(client, ABSENT_TERM);
+            SearchHit[] absentHits = absentResp.getHits().getHits();
+            assertThat((double) absentHits.length, greaterThan(0.0));
+            float absentScore = absentHits[0].getScore();
+
+            // Under constant_score both are 1.0: the df of non-visible docs never enters the score, so the
+            // restricted term is indistinguishable from a term that exists nowhere. Without the bridge
+            // (plain post-filter DLS) restrictedScore would be measurably below absentScore.
+            assertThat(
+                "restricted-term score must equal absent-term score under pre-filter scoring",
+                (double) restrictedScore,
+                closeTo(absentScore, 0.0001)
+            );
+        }
+    }
+}

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -2702,6 +2702,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
             settings.add(SecuritySettings.USER_ATTRIBUTE_SERIALIZATION_ENABLED_SETTING);
             settings.add(SecuritySettings.DLS_WRITE_BLOCKED);
+            settings.add(SecuritySettings.DLS_PRE_FILTER_SCORING);
+            settings.add(SecuritySettings.DLS_MODE);
         }
 
         return settings;

--- a/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
@@ -66,6 +66,7 @@ import org.opensearch.security.privileges.dlsfls.IndexToRuleMap;
 import org.opensearch.security.queries.QueryBuilderTraverser;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.ReflectiveAttributeAccessors;
+import org.opensearch.security.support.SecuritySettings;
 import org.opensearch.security.util.ParentChildrenQueryDetector;
 import org.opensearch.transport.client.Client;
 
@@ -135,6 +136,7 @@ public class DlsFilterLevelActionHandler {
     private final ClusterService clusterService;
     private final IndicesService indicesService;
     private final ThreadContext threadContext;
+    private final boolean preFilterScoring;
     private BoolQueryBuilder filterLevelQueryBuilder;
     private DocumentAllowList documentAllowlist;
 
@@ -160,6 +162,14 @@ public class DlsFilterLevelActionHandler {
         this.requiresIndexScoping = resolved instanceof ResolvedIndices resolvedIndices
             ? resolvedIndices.local().names().size() != 1
             : true;
+
+        // Read the live (dynamically-updatable) value: the handler is constructed per request, and
+        // getClusterSettings().get(...) returns the current cluster-settings value, so a runtime
+        // transient/persistent update to the flag takes effect immediately.
+        this.preFilterScoring = clusterService.getClusterSettings() != null
+            ? clusterService.getClusterSettings().get(SecuritySettings.DLS_PRE_FILTER_SCORING)
+            : clusterService.getSettings()
+                .getAsBoolean(ConfigConstants.SECURITY_DLS_PRE_FILTER_SCORING, ConfigConstants.SECURITY_DLS_PRE_FILTER_SCORING_DEFAULT);
     }
 
     private boolean handle() {
@@ -236,7 +246,17 @@ public class DlsFilterLevelActionHandler {
             filterLevelQueryBuilder.must(query);
         }
 
-        searchRequest.source().query(filterLevelQueryBuilder);
+        if (preFilterScoring) {
+            // Pre-filter scoring: wrap the combined (DLS filter + user query) in a constant_score so
+            // no BM25 IDF is computed. Relevance statistics therefore reflect only the documents the
+            // role can read, rather than the whole shard: a term confined to documents outside the DLS
+            // restriction no longer affects the score of a document the role can see. The returned
+            // document set is unchanged; only relevance scoring is suppressed. Applies to the common
+            // case where the restricted view does not need relevance ranking.
+            searchRequest.source().query(QueryBuilders.constantScoreQuery(filterLevelQueryBuilder));
+        } else {
+            searchRequest.source().query(filterLevelQueryBuilder);
+        }
 
         nodeClient.search(searchRequest, new ActionListener<SearchResponse>() {
             @Override

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 
 import org.opensearch.OpenSearchException;
@@ -110,6 +111,7 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
     private final OpensearchDynamicSetting<Boolean> resourceSharingEnabledSetting;
     private final ResourcePluginInfo resourcePluginInfo;
     private volatile boolean dlsWriteBlockedEnabled;
+    private volatile boolean dlsPreFilterScoring;
 
     public DlsFlsValveImpl(
         Settings settings,
@@ -142,9 +144,16 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
             }
         });
         this.dlsWriteBlockedEnabled = settings.getAsBoolean(SECURITY_DLS_WRITE_BLOCKED, SECURITY_DLS_WRITE_BLOCKED_ENABLED_DEFAULT);
+        this.dlsPreFilterScoring = settings.getAsBoolean(
+            ConfigConstants.SECURITY_DLS_PRE_FILTER_SCORING,
+            ConfigConstants.SECURITY_DLS_PRE_FILTER_SCORING_DEFAULT
+        );
         if (clusterService.getClusterSettings() != null) {
             clusterService.getClusterSettings().addSettingsUpdateConsumer(SecuritySettings.DLS_WRITE_BLOCKED, newDlsWriteBlockedEnabled -> {
                 dlsWriteBlockedEnabled = newDlsWriteBlockedEnabled;
+            });
+            clusterService.getClusterSettings().addSettingsUpdateConsumer(SecuritySettings.DLS_PRE_FILTER_SCORING, newValue -> {
+                dlsPreFilterScoring = newValue;
             });
             clusterService.getClusterSettings()
                 .addSettingsUpdateConsumer(SecuritySettings.DFM_EMPTY_OVERRIDES_ALL_SETTING, newDfmEmptyOverridesAll -> {
@@ -516,7 +525,19 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
 
                 queryBuilder.add(searchContext.parsedQuery().query(), Occur.MUST);
 
-                searchContext.parsedQuery(new ParsedQuery(queryBuilder.build()));
+                Query dlsScopedQuery = queryBuilder.build();
+                if (dlsPreFilterScoring) {
+                    // Pre-filter scoring: wrap the whole (DLS restriction + user query) in a constant_score so
+                    // the user query contributes no BM25 IDF. Without this, the user query is scored as an
+                    // Occur.MUST clause over whole-shard collection statistics, so a term confined to
+                    // documents outside the DLS restriction affects the score of a document the role can
+                    // read. Suppressing scoring here makes relevance statistics reflect only the visible
+                    // subset on the lucene-level search path. The returned document set is unchanged; only
+                    // relevance scoring is suppressed.
+                    dlsScopedQuery = new ConstantScoreQuery(dlsScopedQuery);
+                }
+
+                searchContext.parsedQuery(new ParsedQuery(dlsScopedQuery));
                 searchContext.preProcess(true);
             }
         } catch (Exception e) {

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -350,6 +350,13 @@ public class ConfigConstants {
     public static final String SECURITY_DLS_MODE = SECURITY_SETTINGS_PREFIX + "dls.mode";
     public static final String SECURITY_DLS_WRITE_BLOCKED = SECURITY_SETTINGS_PREFIX + "dls.write_blocked";
     public static final boolean SECURITY_DLS_WRITE_BLOCKED_ENABLED_DEFAULT = false;
+    // When enabled, DLS applies the role's document filter as a pre-filter: the combined query is
+    // wrapped in constant_score so BM25 statistics reflect only the documents the role can read,
+    // instead of being computed over the whole shard and filtered afterwards. This keeps relevance
+    // scores independent of documents outside the DLS restriction, for the (common) case where
+    // relevance ranking is not required. Opt-in; default false preserves today's behavior.
+    public static final String SECURITY_DLS_PRE_FILTER_SCORING = SECURITY_SETTINGS_PREFIX + "dls.pre_filter_scoring";
+    public static final boolean SECURITY_DLS_PRE_FILTER_SCORING_DEFAULT = false;
     // REST API
     public static final String SECURITY_RESTAPI_ROLES_ENABLED = SECURITY_SETTINGS_PREFIX + "restapi.roles_enabled";
     public static final String SECURITY_RESTAPI_ADMIN_ENABLED = SECURITY_SETTINGS_PREFIX + "restapi.admin.enabled";

--- a/src/main/java/org/opensearch/security/support/SecuritySettings.java
+++ b/src/main/java/org/opensearch/security/support/SecuritySettings.java
@@ -64,6 +64,22 @@ public class SecuritySettings {
         Setting.Property.Sensitive
     );
 
+    public static final Setting<Boolean> DLS_PRE_FILTER_SCORING = Setting.boolSetting(
+        ConfigConstants.SECURITY_DLS_PRE_FILTER_SCORING,
+        ConfigConstants.SECURITY_DLS_PRE_FILTER_SCORING_DEFAULT,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    // Registers the existing plugins.security.dls.mode setting (adaptive | lucene_level | filter_level)
+    // so it is accepted by strict settings validation. Previously read via settings.get() without a
+    // registered Setting.
+    public static final Setting<String> DLS_MODE = Setting.simpleString(
+        ConfigConstants.SECURITY_DLS_MODE,
+        "adaptive",
+        Setting.Property.NodeScope
+    );
+
     public static final Setting<Boolean> AUDIT_ENABLED_SETTING = Setting.boolSetting(
         ConfigConstants.SECURITY_AUDIT_ENABLED,
         true,


### PR DESCRIPTION
## Summary

Adds an opt-in setting **`plugins.security.dls.pre_filter_scoring`** (default `false`) that keeps DLS relevance scores within the visible subset. With it on, DLS applies the role's document filter as a *pre-filter* (the combined DLS-restriction + user query is wrapped in `constant_score`), so BM25 collection statistics reflect only the documents the role can read — instead of being computed over the whole shard and filtered afterward.

## Motivation

Under plain DLS, relevance **scores** depend on documents the role cannot see: a term that occurs only in restricted documents inflates that term's corpus-wide document frequency, which lowers its BM25 IDF and therefore the score of a *visible* document containing it. So a restricted user's scores vary with data they have no read access to. The returned documents are correctly filtered — this is purely about relevance scoring being a function of the whole shard rather than the visible subset. Pre-filtering makes scores depend only on the visible subset.

## What changed

Both DLS search paths are covered (default off preserves today's behavior):

| Path | Where DLS applies today | Fix |
|---|---|---|
| **filter-level** (`DlsFilterLevelActionHandler`) | re-issues the search with the filter as `bool.must` | wrap re-issued query in `constant_score` |
| **lucene-level / default ADAPTIVE** (`DlsFlsValveImpl`) | injects the DLS query into the search context; user query added as scored `Occur.MUST` over whole-shard stats | wrap the DLS-scoped query in `constant_score` |

- `constant_score` suppresses IDF, so a term confined to restricted docs no longer affects visible-doc scores.
- **Dynamic:** the valve registers a settings-update consumer and the filter-level handler reads the live value per request — a runtime `transient`/`persistent` update takes effect without a node restart.
- Also registers the previously-unregistered `plugins.security.dls.mode` setting (was read via `settings.get()` without a registered `Setting`, so strict-settings validation rejected it in tests).

## Verification

Live on a 3.8.0-SNAPSHOT cluster in **ADAPTIVE** mode (the default path):

- **Before (flag off):** a term confined to restricted docs scored **2.19** vs a nonexistent term **7.14** — scores varying with non-visible data.
- **After (flag on):** both score **1.0** — scores depend only on the visible subset. Document isolation intact (user sees only their subset).

Integration test `DlsPreFilterScoringIntegrationTest` (2/2) asserts isolation + score-equality on the filter-level path.

## Scope / follow-up

`constant_score` suppresses relevance ranking — correct and fast for the common restricted-view case that doesn't need ranking. **Ranked** restricted views (real relevance over visible-only statistics) are a separate `filtered_stats` effort (OpenSearch core `feat/filter-aware-alias`), not in this PR.

> Note: this branch is based on `upstream/main`; the fork's `main` has diverged, so the PR diff includes upstream catch-up commits. The substantive change is the single commit the single commit on this branch.

Commit currently unsigned (signing agent unavailable in the build environment); can re-sign on request.
