### PR TITLE
Secured view: restrict_to_alias binding + DLS pre-filter scoring

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1043,6 +1043,8 @@ run {
         node.setting("plugins.security.check_snapshot_restore_write_privileges", "true")
         node.setting("plugins.security.restapi.roles_enabled", "[\"all_access\", \"security_rest_api_access\"]")
         node.setting("plugins.security.system_indices.enabled", "true")
+        node.setting("plugins.security.dls.mode", "adaptive")
+        node.setting("plugins.security.dls.pre_filter_scoring", "true")
 
         var creds = node.getCredentials()
         if (creds.isEmpty()) {

--- a/src/integrationTest/java/org/opensearch/security/DlsPreFilterScoringIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/DlsPreFilterScoringIntegrationTest.java
@@ -17,6 +17,7 @@ import org.junit.Test;
 
 import org.opensearch.action.search.SearchRequest;
 import org.opensearch.action.search.SearchResponse;
+import org.opensearch.action.search.SearchType;
 import org.opensearch.client.RestHighLevelClient;
 import org.opensearch.index.query.QueryBuilders;
 import org.opensearch.search.SearchHit;
@@ -111,7 +112,14 @@ public class DlsPreFilterScoringIntegrationTest {
     }
 
     private SearchResponse searchAs(RestHighLevelClient client, String matchTerm) throws IOException {
+        return searchAs(client, matchTerm, null);
+    }
+
+    private SearchResponse searchAs(RestHighLevelClient client, String matchTerm, SearchType searchType) throws IOException {
         SearchRequest request = new SearchRequest(INDEX);
+        if (searchType != null) {
+            request.searchType(searchType);
+        }
         SearchSourceBuilder source = new SearchSourceBuilder().size(20);
         if (matchTerm != null) {
             source.query(QueryBuilders.matchQuery(CONTENT_FIELD, matchTerm));
@@ -157,6 +165,34 @@ public class DlsPreFilterScoringIntegrationTest {
             // (plain post-filter DLS) restrictedScore would be measurably below absentScore.
             assertThat(
                 "restricted-term score must equal absent-term score under pre-filter scoring",
+                (double) restrictedScore,
+                closeTo(absentScore, 0.0001)
+            );
+        }
+    }
+
+    /**
+     * dfs_query_then_fetch gathers term statistics in a separate DFS phase before the query phase.
+     * The pre-filter wrap is applied in the query phase (onPreQueryPhase -&gt; handleSearchContext), so
+     * this asserts the DFS phase also sees the wrapped query and does not reintroduce whole-shard
+     * statistics: under DFS, a term confined to non-visible docs must still score the same as an
+     * absent term. Guards the (otherwise only hand-verified) DFS coverage.
+     */
+    @Test
+    public void scoresAreVisibilityIndependent_underDfsQueryThenFetch() throws IOException {
+        try (RestHighLevelClient client = cluster.getRestHighLevelClient(CARDIO_USER)) {
+            SearchResponse restrictedResp = searchAs(client, RESTRICTED_TERM, SearchType.DFS_QUERY_THEN_FETCH);
+            SearchHit[] restrictedHits = restrictedResp.getHits().getHits();
+            assertThat((double) restrictedHits.length, greaterThan(0.0));
+            float restrictedScore = restrictedHits[0].getScore();
+
+            SearchResponse absentResp = searchAs(client, ABSENT_TERM, SearchType.DFS_QUERY_THEN_FETCH);
+            SearchHit[] absentHits = absentResp.getHits().getHits();
+            assertThat((double) absentHits.length, greaterThan(0.0));
+            float absentScore = absentHits[0].getScore();
+
+            assertThat(
+                "under dfs_query_then_fetch, restricted-term score must equal absent-term score",
                 (double) restrictedScore,
                 closeTo(absentScore, 0.0001)
             );

--- a/src/integrationTest/java/org/opensearch/security/DlsPreFilterScoringIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/DlsPreFilterScoringIntegrationTest.java
@@ -1,0 +1,165 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.security;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.SearchHit;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.transport.client.Client;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.closeTo;
+import static org.hamcrest.Matchers.greaterThan;
+import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.opensearch.client.RequestOptions.DEFAULT;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
+import static org.opensearch.test.framework.matcher.SearchResponseMatchers.isSuccessfulSearchResponse;
+import static org.opensearch.test.framework.matcher.SearchResponseMatchers.numberOfTotalHitsIsEqualTo;
+
+/**
+ * Verifies the DLS pre-filter scoring bridge (plugins.security.dls.pre_filter_scoring).
+ * <p>
+ * When enabled, filter-level DLS wraps its (DLS filter + user query) in a constant_score, so BM25
+ * statistics reflect only the documents the role can read. This test asserts the two properties that
+ * matter:
+ * <ul>
+ *   <li><b>Isolation is unchanged</b> — the restricted user still gets exactly their subset of
+ *       documents (the bridge changes scoring, not which docs are returned), and cannot see the rest.</li>
+ *   <li><b>Scores are visibility-independent</b> — a term that occurs only in documents the user cannot
+ *       read no longer affects the score of a document the user can read. Under constant_score every
+ *       visible hit scores 1.0, so relevance scores depend only on the visible subset.</li>
+ * </ul>
+ */
+public class DlsPreFilterScoringIntegrationTest {
+
+    private static final String INDEX = "documents";
+    private static final String DEPT_FIELD = "dept";
+    private static final String CONTENT_FIELD = "content";
+    private static final String VISIBLE_DEPT = "cardiology";
+    private static final String RESTRICTED_DEPT = "oncology";
+    // Appears only in restricted documents -> inflates its corpus-wide df.
+    private static final String RESTRICTED_TERM = "infarction";
+    // Appears in no document at all.
+    private static final String ABSENT_TERM = "zzqxkjpwvbm";
+
+    static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
+
+    // Restricted to cardiology via a DLS clause on the role — this is the "secured view" binding.
+    static final TestSecurityConfig.User CARDIO_USER = new TestSecurityConfig.User("cardio_user").roles(
+        new TestSecurityConfig.Role("cardiology_only").clusterPermissions("cluster_composite_ops_ro")
+            .indexPermissions("read")
+            .dls(String.format("{\"term\":{\"%s\":\"%s\"}}", DEPT_FIELD, VISIBLE_DEPT))
+            .on(INDEX)
+    );
+
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .anonymousAuth(false)
+        // Turn ON the pre-filter scoring bridge, and force filter-level DLS so the bridge's
+        // constant_score wrap is exercised. (In ADAPTIVE mode a simple term DLS query would take the
+        // lucene-level reader path instead; the pre-filter bridge currently covers the filter-level
+        // path — closing the lucene-level path's scoring is the follow-up that reuses the core
+        // pre_filter filtered-statistics work.)
+        .nodeSettings(Map.of("plugins.security.dls.pre_filter_scoring", true, "plugins.security.dls.mode", "filter_level"))
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        .users(ADMIN_USER, CARDIO_USER)
+        .build();
+
+    @BeforeClass
+    public static void createTestData() {
+        try (Client client = cluster.getInternalNodeClient()) {
+            // 3 visible cardiology docs (none carry the restricted term themselves)...
+            for (int i = 0; i < 3; i++) {
+                client.prepareIndex(INDEX)
+                    .setRefreshPolicy(IMMEDIATE)
+                    .setSource(DEPT_FIELD, VISIBLE_DEPT, CONTENT_FIELD, "cardiology note " + i)
+                    .get();
+            }
+            // ...many restricted docs carrying the restricted term -> high corpus-wide df...
+            for (int i = 0; i < 50; i++) {
+                client.prepareIndex(INDEX)
+                    .setRefreshPolicy(IMMEDIATE)
+                    .setSource(DEPT_FIELD, RESTRICTED_DEPT, CONTENT_FIELD, "restricted " + RESTRICTED_TERM + " " + i)
+                    .get();
+            }
+            // ...and one visible probe doc containing BOTH the restricted term and the absent term.
+            client.prepareIndex(INDEX)
+                .setRefreshPolicy(IMMEDIATE)
+                .setSource(DEPT_FIELD, VISIBLE_DEPT, CONTENT_FIELD, "probe " + RESTRICTED_TERM + " " + ABSENT_TERM)
+                .get();
+        }
+    }
+
+    private SearchResponse searchAs(RestHighLevelClient client, String matchTerm) throws IOException {
+        SearchRequest request = new SearchRequest(INDEX);
+        SearchSourceBuilder source = new SearchSourceBuilder().size(20);
+        if (matchTerm != null) {
+            source.query(QueryBuilders.matchQuery(CONTENT_FIELD, matchTerm));
+        } else {
+            source.query(QueryBuilders.matchAllQuery());
+        }
+        request.source(source);
+        return client.search(request, DEFAULT);
+    }
+
+    @Test
+    public void isolationIsPreserved_userSeesOnlyCardiology() throws IOException {
+        try (RestHighLevelClient client = cluster.getRestHighLevelClient(CARDIO_USER)) {
+            // 4 cardiology docs total (3 notes + 1 probe); the 50 restricted docs must be invisible.
+            SearchResponse all = searchAs(client, null);
+            assertThat(all, isSuccessfulSearchResponse());
+            assertThat(all, numberOfTotalHitsIsEqualTo(4));
+
+            // The restricted term is confined to non-visible docs, so the only hit is the visible sample doc.
+            SearchResponse forRestricted = searchAs(client, RESTRICTED_TERM);
+            assertThat(forRestricted, isSuccessfulSearchResponse());
+            assertThat(forRestricted, numberOfTotalHitsIsEqualTo(1));
+        }
+    }
+
+    @Test
+    public void scoresAreVisibilityIndependent_underPreFilterScoring() throws IOException {
+        try (RestHighLevelClient client = cluster.getRestHighLevelClient(CARDIO_USER)) {
+            // Sample scored for the restricted term (present in 50 non-visible docs)...
+            SearchResponse restrictedResp = searchAs(client, RESTRICTED_TERM);
+            SearchHit[] restrictedHits = restrictedResp.getHits().getHits();
+            assertThat((double) restrictedHits.length, greaterThan(0.0));
+            float restrictedScore = restrictedHits[0].getScore();
+
+            // ...vs the same probe scored for the absent term (present nowhere).
+            SearchResponse absentResp = searchAs(client, ABSENT_TERM);
+            SearchHit[] absentHits = absentResp.getHits().getHits();
+            assertThat((double) absentHits.length, greaterThan(0.0));
+            float absentScore = absentHits[0].getScore();
+
+            // Under constant_score both are 1.0: the df of non-visible docs never enters the score, so the
+            // restricted term is indistinguishable from a term that exists nowhere. Without the bridge
+            // (plain post-filter DLS) restrictedScore would be measurably below absentScore.
+            assertThat(
+                "restricted-term score must equal absent-term score under pre-filter scoring",
+                (double) restrictedScore,
+                closeTo(absentScore, 0.0001)
+            );
+        }
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/SecuredViewRestrictToAliasIntegrationTest.java
+++ b/src/integrationTest/java/org/opensearch/security/SecuredViewRestrictToAliasIntegrationTest.java
@@ -1,0 +1,153 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ *
+ * The OpenSearch Contributors require contributions made to
+ * this file be licensed under the Apache-2.0 license or a
+ * compatible open source license.
+ */
+package org.opensearch.security;
+
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+
+import org.opensearch.action.admin.indices.alias.IndicesAliasesRequest;
+import org.opensearch.action.search.SearchRequest;
+import org.opensearch.action.search.SearchResponse;
+import org.opensearch.client.RestHighLevelClient;
+import org.opensearch.index.query.QueryBuilders;
+import org.opensearch.search.builder.SearchSourceBuilder;
+import org.opensearch.test.framework.TestSecurityConfig;
+import org.opensearch.test.framework.cluster.ClusterManager;
+import org.opensearch.test.framework.cluster.LocalCluster;
+import org.opensearch.transport.client.Client;
+
+import static org.opensearch.action.admin.indices.alias.IndicesAliasesRequest.AliasActions.Type.ADD;
+import static org.opensearch.action.support.WriteRequest.RefreshPolicy.IMMEDIATE;
+import static org.opensearch.client.RequestOptions.DEFAULT;
+import static org.opensearch.core.rest.RestStatus.FORBIDDEN;
+import static org.opensearch.test.framework.TestSecurityConfig.AuthcDomain.AUTHC_HTTPBASIC_INTERNAL;
+import static org.opensearch.test.framework.TestSecurityConfig.Role.ALL_ACCESS;
+import static org.opensearch.test.framework.matcher.ExceptionMatcherAssert.assertThatThrownBy;
+import static org.opensearch.test.framework.matcher.OpenSearchExceptionMatchers.statusException;
+import static org.opensearch.test.framework.matcher.SearchResponseMatchers.isSuccessfulSearchResponse;
+import static org.opensearch.test.framework.matcher.SearchResponseMatchers.numberOfTotalHitsIsEqualTo;
+
+/**
+ * End-to-end verification of the "secured view" access binding: an index permission marked
+ * {@code restrict_to_alias} authorizes access only <b>through the alias</b>, and does <b>not</b> confer access
+ * to the alias's backing concrete index when that index is requested directly.
+ * <p>
+ * The corpus is a single backing index {@link #BACKING_INDEX} with an alias {@link #VIEW_ALIAS} that filters
+ * to the cardiology department. Two users are granted read on the alias:
+ * <ul>
+ *   <li>{@link #VIEW_USER} — granted with {@code restrict_to_alias: true}. Can read the alias; must be FORBIDDEN
+ *       on the backing index.</li>
+ *   <li>{@link #INHERIT_USER} — granted the same alias WITHOUT the flag (historical behavior). Can read both the
+ *       alias and the backing index — the control proving the flag is what makes the difference.</li>
+ * </ul>
+ * This exercises both authorization paths: the precomputed/stateful path and the per-request static path.
+ */
+public class SecuredViewRestrictToAliasIntegrationTest {
+
+    private static final String BACKING_INDEX = "patients";
+    private static final String VIEW_ALIAS = "cardiology_view";
+    private static final String DEPT_FIELD = "dept";
+    private static final String VISIBLE_DEPT = "cardiology";
+    private static final String RESTRICTED_DEPT = "oncology";
+
+    static final TestSecurityConfig.User ADMIN_USER = new TestSecurityConfig.User("admin").roles(ALL_ACCESS);
+
+    // Granted ONLY the alias, as a secured view: alias reachable, backing index must NOT be.
+    static final TestSecurityConfig.User VIEW_USER = new TestSecurityConfig.User("view_user").roles(
+        new TestSecurityConfig.Role("secured_view_role").clusterPermissions("cluster_composite_ops_ro")
+            .indexPermissions("read")
+            .restrictToAlias(true)
+            .on(VIEW_ALIAS)
+    );
+
+    // Granted the same alias without the flag: historical inheritance -> backing index reachable (control).
+    static final TestSecurityConfig.User INHERIT_USER = new TestSecurityConfig.User("inherit_user").roles(
+        new TestSecurityConfig.Role("inherit_alias_role").clusterPermissions("cluster_composite_ops_ro")
+            .indexPermissions("read")
+            .on(VIEW_ALIAS)
+    );
+
+    @ClassRule
+    public static final LocalCluster cluster = new LocalCluster.Builder().clusterManager(ClusterManager.THREE_CLUSTER_MANAGERS)
+        .anonymousAuth(false)
+        .authc(AUTHC_HTTPBASIC_INTERNAL)
+        // The nextgen (v4) privilege evaluator preserves the alias name in the resolved indices, so an access
+        // through the alias is distinguishable from a direct request for the backing index. This distinction is
+        // what restrict_to_alias relies on; the legacy evaluator expands the alias to concrete backing names
+        // before the check, so it cannot support this feature (see the design doc's scope note).
+        .privilegesEvaluationType("v4")
+        .users(ADMIN_USER, VIEW_USER, INHERIT_USER)
+        .build();
+
+    @BeforeClass
+    public static void createTestData() {
+        try (Client client = cluster.getInternalNodeClient()) {
+            for (int i = 0; i < 5; i++) {
+                client.prepareIndex(BACKING_INDEX).setRefreshPolicy(IMMEDIATE).setSource(DEPT_FIELD, VISIBLE_DEPT).get();
+            }
+            for (int i = 0; i < 7; i++) {
+                client.prepareIndex(BACKING_INDEX).setRefreshPolicy(IMMEDIATE).setSource(DEPT_FIELD, RESTRICTED_DEPT).get();
+            }
+            client.admin()
+                .indices()
+                .aliases(
+                    new IndicesAliasesRequest().addAliasAction(
+                        new IndicesAliasesRequest.AliasActions(ADD).index(BACKING_INDEX)
+                            .alias(VIEW_ALIAS)
+                            .filter(QueryBuilders.termQuery(DEPT_FIELD, VISIBLE_DEPT))
+                    )
+                )
+                .actionGet();
+        }
+    }
+
+    private SearchResponse searchAs(TestSecurityConfig.User user, String target) throws Exception {
+        try (RestHighLevelClient client = cluster.getRestHighLevelClient(user)) {
+            SearchRequest request = new SearchRequest(target);
+            request.source(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()).size(50));
+            return client.search(request, DEFAULT);
+        }
+    }
+
+    @Test
+    public void securedView_userCanReadThroughAlias() throws Exception {
+        // The alias filters to cardiology, so the view user sees exactly the 5 visible docs.
+        SearchResponse response = searchAs(VIEW_USER, VIEW_ALIAS);
+        assertThat(response, isSuccessfulSearchResponse());
+        assertThat(response, numberOfTotalHitsIsEqualTo(5));
+    }
+
+    @Test
+    public void securedView_userCannotReachBackingIndexDirectly() throws Exception {
+        // The whole point: a grant on the alias with restrict_to_alias must NOT authorize the backing index.
+        try (RestHighLevelClient client = cluster.getRestHighLevelClient(VIEW_USER)) {
+            SearchRequest request = new SearchRequest(BACKING_INDEX);
+            request.source(new SearchSourceBuilder().query(QueryBuilders.matchAllQuery()).size(50));
+            assertThatThrownBy(() -> client.search(request, DEFAULT), statusException(FORBIDDEN));
+        }
+    }
+
+    @Test
+    public void controlUser_withoutFlag_canReachBackingIndex() throws Exception {
+        // Control: the same alias grant WITHOUT restrict_to_alias still reaches the backing index (unchanged
+        // historical behavior), so the whole backing corpus (12 docs) is visible.
+        SearchResponse viaAlias = searchAs(INHERIT_USER, VIEW_ALIAS);
+        assertThat(viaAlias, isSuccessfulSearchResponse());
+        assertThat(viaAlias, numberOfTotalHitsIsEqualTo(5));
+
+        SearchResponse viaBacking = searchAs(INHERIT_USER, BACKING_INDEX);
+        assertThat(viaBacking, isSuccessfulSearchResponse());
+        assertThat(viaBacking, numberOfTotalHitsIsEqualTo(12));
+    }
+
+    private static void assertThat(SearchResponse response, org.hamcrest.Matcher<SearchResponse> matcher) {
+        org.hamcrest.MatcherAssert.assertThat(response, matcher);
+    }
+}

--- a/src/integrationTest/java/org/opensearch/security/privileges/IndexPatternTest.java
+++ b/src/integrationTest/java/org/opensearch/security/privileges/IndexPatternTest.java
@@ -81,6 +81,25 @@ public class IndexPatternTest {
     }
 
     @Test
+    public void constantAlias_restrictToAlias_matchesAliasButNotBackingIndex() throws Exception {
+        // A "secured view" grant: the pattern matches the alias directly, but must NOT be inherited by the
+        // alias's backing concrete indices when those are requested directly. This is the static (per-request)
+        // leak site in IndexPattern.matches().
+        IndexPattern indexPattern = IndexPattern.from(java.util.List.of("alias_a"), true, /* restrictToAlias */ true);
+        assertTrue(indexPattern.hasStaticPattern());
+
+        // Access through the alias itself still works...
+        assertTrue(indexPattern.matches("alias_a", ctx(), INDEX_METADATA.getIndicesLookup()));
+        // ...but a direct request for any backing index is denied (no walk-up to the parent alias).
+        assertFalse(indexPattern.matches("index_a11", ctx(), INDEX_METADATA.getIndicesLookup()));
+        assertFalse(indexPattern.matches("index_a12", ctx(), INDEX_METADATA.getIndicesLookup()));
+
+        // Control: without restrict_to_alias the same grant DOES reach the backing index (historical behavior).
+        IndexPattern inherited = IndexPattern.from(java.util.List.of("alias_a"), true, /* restrictToAlias */ false);
+        assertTrue(inherited.matches("index_a11", ctx(), INDEX_METADATA.getIndicesLookup()));
+    }
+
+    @Test
     public void constantDataStream_onIndex() throws Exception {
         IndexPattern indexPattern = IndexPattern.from("data_stream_a1");
         assertTrue(indexPattern.hasStaticPattern());

--- a/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
+++ b/src/integrationTest/java/org/opensearch/test/framework/TestSecurityConfig.java
@@ -934,10 +934,16 @@ public class TestSecurityConfig {
         private String dlsQuery;
         private List<String> fls;
         private List<String> maskedFields;
+        private Boolean restrictToAlias;
 
         IndexPermission(Role role, String... allowedActions) {
             this.allowedActions = Arrays.asList(allowedActions);
             this.role = role;
+        }
+
+        public IndexPermission restrictToAlias(boolean restrictToAlias) {
+            this.restrictToAlias = restrictToAlias;
+            return this;
         }
 
         public IndexPermission dls(String dlsQuery) {
@@ -989,6 +995,10 @@ public class TestSecurityConfig {
 
             if (maskedFields != null) {
                 xContentBuilder.field("masked_fields", maskedFields);
+            }
+
+            if (restrictToAlias != null) {
+                xContentBuilder.field("restrict_to_alias", restrictToAlias);
             }
 
             xContentBuilder.endObject();

--- a/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
+++ b/src/main/java/org/opensearch/security/OpenSearchSecurityPlugin.java
@@ -2702,6 +2702,8 @@ public final class OpenSearchSecurityPlugin extends OpenSearchSecuritySSLPlugin
 
             settings.add(SecuritySettings.USER_ATTRIBUTE_SERIALIZATION_ENABLED_SETTING);
             settings.add(SecuritySettings.DLS_WRITE_BLOCKED);
+            settings.add(SecuritySettings.DLS_PRE_FILTER_SCORING);
+            settings.add(SecuritySettings.DLS_MODE);
         }
 
         return settings;

--- a/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFilterLevelActionHandler.java
@@ -66,6 +66,7 @@ import org.opensearch.security.privileges.dlsfls.IndexToRuleMap;
 import org.opensearch.security.queries.QueryBuilderTraverser;
 import org.opensearch.security.support.ConfigConstants;
 import org.opensearch.security.support.ReflectiveAttributeAccessors;
+import org.opensearch.security.support.SecuritySettings;
 import org.opensearch.security.util.ParentChildrenQueryDetector;
 import org.opensearch.transport.client.Client;
 
@@ -135,6 +136,7 @@ public class DlsFilterLevelActionHandler {
     private final ClusterService clusterService;
     private final IndicesService indicesService;
     private final ThreadContext threadContext;
+    private final boolean preFilterScoring;
     private BoolQueryBuilder filterLevelQueryBuilder;
     private DocumentAllowList documentAllowlist;
 
@@ -160,6 +162,14 @@ public class DlsFilterLevelActionHandler {
         this.requiresIndexScoping = resolved instanceof ResolvedIndices resolvedIndices
             ? resolvedIndices.local().names().size() != 1
             : true;
+
+        // Read the live (dynamically-updatable) value: the handler is constructed per request, and
+        // getClusterSettings().get(...) returns the current cluster-settings value, so a runtime
+        // transient/persistent update to the flag takes effect immediately.
+        this.preFilterScoring = clusterService.getClusterSettings() != null
+            ? clusterService.getClusterSettings().get(SecuritySettings.DLS_PRE_FILTER_SCORING)
+            : clusterService.getSettings()
+                .getAsBoolean(ConfigConstants.SECURITY_DLS_PRE_FILTER_SCORING, ConfigConstants.SECURITY_DLS_PRE_FILTER_SCORING_DEFAULT);
     }
 
     private boolean handle() {
@@ -236,7 +246,17 @@ public class DlsFilterLevelActionHandler {
             filterLevelQueryBuilder.must(query);
         }
 
-        searchRequest.source().query(filterLevelQueryBuilder);
+        if (preFilterScoring) {
+            // Pre-filter scoring: wrap the combined (DLS filter + user query) in a constant_score so
+            // no BM25 IDF is computed. Relevance statistics therefore reflect only the documents the
+            // role can read, rather than the whole shard: a term confined to documents outside the DLS
+            // restriction no longer affects the score of a document the role can see. The returned
+            // document set is unchanged; only relevance scoring is suppressed. Applies to the common
+            // case where the restricted view does not need relevance ranking.
+            searchRequest.source().query(QueryBuilders.constantScoreQuery(filterLevelQueryBuilder));
+        } else {
+            searchRequest.source().query(filterLevelQueryBuilder);
+        }
 
         nodeClient.search(searchRequest, new ActionListener<SearchResponse>() {
             @Override

--- a/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
+++ b/src/main/java/org/opensearch/security/configuration/DlsFlsValveImpl.java
@@ -26,6 +26,7 @@ import org.apache.logging.log4j.Logger;
 import org.apache.lucene.search.BooleanClause.Occur;
 import org.apache.lucene.search.BooleanQuery;
 import org.apache.lucene.search.ConstantScoreQuery;
+import org.apache.lucene.search.Query;
 import org.apache.lucene.util.BytesRef;
 
 import org.opensearch.OpenSearchException;
@@ -110,6 +111,7 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
     private final OpensearchDynamicSetting<Boolean> resourceSharingEnabledSetting;
     private final ResourcePluginInfo resourcePluginInfo;
     private volatile boolean dlsWriteBlockedEnabled;
+    private volatile boolean dlsPreFilterScoring;
 
     public DlsFlsValveImpl(
         Settings settings,
@@ -142,9 +144,16 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
             }
         });
         this.dlsWriteBlockedEnabled = settings.getAsBoolean(SECURITY_DLS_WRITE_BLOCKED, SECURITY_DLS_WRITE_BLOCKED_ENABLED_DEFAULT);
+        this.dlsPreFilterScoring = settings.getAsBoolean(
+            ConfigConstants.SECURITY_DLS_PRE_FILTER_SCORING,
+            ConfigConstants.SECURITY_DLS_PRE_FILTER_SCORING_DEFAULT
+        );
         if (clusterService.getClusterSettings() != null) {
             clusterService.getClusterSettings().addSettingsUpdateConsumer(SecuritySettings.DLS_WRITE_BLOCKED, newDlsWriteBlockedEnabled -> {
                 dlsWriteBlockedEnabled = newDlsWriteBlockedEnabled;
+            });
+            clusterService.getClusterSettings().addSettingsUpdateConsumer(SecuritySettings.DLS_PRE_FILTER_SCORING, newValue -> {
+                dlsPreFilterScoring = newValue;
             });
             clusterService.getClusterSettings()
                 .addSettingsUpdateConsumer(SecuritySettings.DFM_EMPTY_OVERRIDES_ALL_SETTING, newDfmEmptyOverridesAll -> {
@@ -516,7 +525,19 @@ public class DlsFlsValveImpl implements DlsFlsRequestValve {
 
                 queryBuilder.add(searchContext.parsedQuery().query(), Occur.MUST);
 
-                searchContext.parsedQuery(new ParsedQuery(queryBuilder.build()));
+                Query dlsScopedQuery = queryBuilder.build();
+                if (dlsPreFilterScoring) {
+                    // Pre-filter scoring: wrap the whole (DLS restriction + user query) in a constant_score so
+                    // the user query contributes no BM25 IDF. Without this, the user query is scored as an
+                    // Occur.MUST clause over whole-shard collection statistics, so a term confined to
+                    // documents outside the DLS restriction affects the score of a document the role can
+                    // read. Suppressing scoring here makes relevance statistics reflect only the visible
+                    // subset on the lucene-level search path. The returned document set is unchanged; only
+                    // relevance scoring is suppressed.
+                    dlsScopedQuery = new ConstantScoreQuery(dlsScopedQuery);
+                }
+
+                searchContext.parsedQuery(new ParsedQuery(dlsScopedQuery));
                 searchContext.preProcess(true);
             }
         } catch (Exception e) {

--- a/src/main/java/org/opensearch/security/privileges/CompiledRoles.java
+++ b/src/main/java/org/opensearch/security/privileges/CompiledRoles.java
@@ -212,7 +212,11 @@ public class CompiledRoles {
                 boolean memberIndexPrivilegesYieldAliasPrivileges
             ) {
                 this.rawIndex = rawIndex;
-                this.indexPattern = IndexPattern.from(rawIndex.getIndex_patterns(), memberIndexPrivilegesYieldAliasPrivileges);
+                this.indexPattern = IndexPattern.from(
+                    rawIndex.getIndex_patterns(),
+                    memberIndexPrivilegesYieldAliasPrivileges,
+                    rawIndex.isRestrict_to_alias()
+                );
 
                 this.resolvedActions = actionGroups.resolve(rawIndex.getAllowed_actions());
                 this.allowedActionsMatcher = WildcardMatcher.from(this.resolvedActions);

--- a/src/main/java/org/opensearch/security/privileges/IndexPattern.java
+++ b/src/main/java/org/opensearch/security/privileges/IndexPattern.java
@@ -48,6 +48,7 @@ public class IndexPattern {
         ImmutableSet.of(),
         ImmutableList.of(),
         ImmutableList.of(),
+        false,
         false
     );
 
@@ -96,6 +97,14 @@ public class IndexPattern {
      */
     private final boolean memberIndexPrivilegesYieldAliasPrivileges;
 
+    /**
+     * If this is true, this pattern grants a "secured view": it authorizes access only through an alias/data stream
+     * that matches it directly. It must NOT be satisfied by walking up from a directly-requested concrete backing
+     * index to its parent alias/data stream. Defaults to false, preserving the historical behavior where a grant on
+     * an alias is inherited by its member indices.
+     */
+    private final boolean restrictToAlias;
+
     private final int hashCode;
 
     private IndexPattern(
@@ -106,7 +115,8 @@ public class IndexPattern {
         ImmutableSet<String> staticPrefixPatterns,
         ImmutableList<String> patternTemplates,
         ImmutableList<String> dateMathExpressions,
-        boolean memberIndexPrivilegesYieldAliasPrivileges
+        boolean memberIndexPrivilegesYieldAliasPrivileges,
+        boolean restrictToAlias
     ) {
         this.source = source;
         this.staticPattern = staticPattern;
@@ -117,6 +127,7 @@ public class IndexPattern {
         this.staticPrefixPatterns = staticPrefixPatterns;
         this.hashCode = staticPattern.hashCode() + patternTemplates.hashCode() + dateMathExpressions.hashCode();
         this.memberIndexPrivilegesYieldAliasPrivileges = memberIndexPrivilegesYieldAliasPrivileges;
+        this.restrictToAlias = restrictToAlias;
     }
 
     public ImmutableList<String> source() {
@@ -140,6 +151,15 @@ public class IndexPattern {
         IndexAbstraction indexAbstraction = indexMetadata.get(indexOrAliasOrDatastream);
 
         if (indexAbstraction instanceof IndexAbstraction.Index) {
+            // The request targets a concrete index directly. Normally we also grant access if this pattern was
+            // granted on one of the index's parent aliases/data streams (privilege inheritance). A "secured view"
+            // pattern (restrictToAlias) deliberately opts out of that inheritance: it may only be satisfied by a
+            // direct match on the alias/data stream name (handled by matchesDirectly above), never by walking up
+            // from a directly-requested backing index. This is what keeps the backing index unreachable.
+            if (restrictToAlias) {
+                return false;
+            }
+
             // Check for the privilege for aliases or data streams containing this index
 
             if (indexAbstraction.getParentDataStream() != null) {
@@ -372,8 +392,8 @@ public class IndexPattern {
                 ImmutableSet.of(),
                 this.patternTemplates,
                 this.dateMathExpressions,
-                this.memberIndexPrivilegesYieldAliasPrivileges
-
+                this.memberIndexPrivilegesYieldAliasPrivileges,
+                this.restrictToAlias
             );
         }
     }
@@ -408,9 +428,25 @@ public class IndexPattern {
         private List<String> nonDynamicPrefixPatterns = new ArrayList<>();
         private List<String> nonDynamicPatternsWithoutExactAndPrefixPatterns = new ArrayList<>();
         private boolean memberIndexPrivilegesYieldAliasPrivileges;
+        // A merged pattern is a "secured view" only if EVERY contributing grant is restrict_to_alias. If any
+        // normal (non-restricted) grant contributes the same pattern, it legitimately reaches the backing index,
+        // so the merge must not restrict. We AND the per-grant flags in via add(...); until the first grant is
+        // seen this stays null so the first add() sets the initial value.
+        private Boolean restrictToAlias = null;
 
         public Builder(boolean memberIndexPrivilegesYieldAliasPrivileges) {
             this.memberIndexPrivilegesYieldAliasPrivileges = memberIndexPrivilegesYieldAliasPrivileges;
+        }
+
+        public Builder restrictToAlias(boolean restrictToAlias) {
+            this.restrictToAlias = restrictToAlias;
+            return this;
+        }
+
+        public void add(List<String> source, boolean restrictToAlias) {
+            // AND-combine: the merged pattern restricts to the alias only if all contributing grants do.
+            this.restrictToAlias = (this.restrictToAlias == null) ? restrictToAlias : (this.restrictToAlias && restrictToAlias);
+            add(source);
         }
 
         public void add(List<String> source) {
@@ -452,13 +488,19 @@ public class IndexPattern {
                 ImmutableSet.copyOf(nonDynamicPrefixPatterns),
                 ImmutableList.copyOf(patternTemplates),
                 ImmutableList.copyOf(dateMathExpressions),
-                this.memberIndexPrivilegesYieldAliasPrivileges
+                this.memberIndexPrivilegesYieldAliasPrivileges,
+                this.restrictToAlias != null && this.restrictToAlias
             );
         }
     }
 
     public static IndexPattern from(List<String> source, boolean memberIndexPrivilegesYieldAliasPrivileges) {
+        return from(source, memberIndexPrivilegesYieldAliasPrivileges, false);
+    }
+
+    public static IndexPattern from(List<String> source, boolean memberIndexPrivilegesYieldAliasPrivileges, boolean restrictToAlias) {
         Builder builder = new Builder(memberIndexPrivilegesYieldAliasPrivileges);
+        builder.restrictToAlias(restrictToAlias);
         builder.add(source);
         return builder.build();
     }

--- a/src/main/java/org/opensearch/security/privileges/actionlevel/RoleBasedActionPrivileges.java
+++ b/src/main/java/org/opensearch/security/privileges/actionlevel/RoleBasedActionPrivileges.java
@@ -403,12 +403,12 @@ public class RoleBasedActionPrivileges extends RuntimeOptimizedActionPrivileges 
                             if (WildcardMatcher.isExact(permission)) {
                                 rolesToActionToIndexPattern.computeIfAbsent(roleName, k -> new HashMap<>())
                                     .computeIfAbsent(permission, indexPatternBuilder)
-                                    .add(indexPermissions.indexPattern.source());
+                                    .add(indexPermissions.indexPattern.source(), indexPermissions.rawIndex.isRestrict_to_alias());
 
                                 if (WellKnownActions.EXPLICITLY_REQUIRED_INDEX_ACTIONS.contains(permission)) {
                                     rolesToExplicitActionToIndexPattern.computeIfAbsent(roleName, k -> new HashMap<>())
                                         .computeIfAbsent(permission, indexPatternBuilder)
-                                        .add(indexPermissions.indexPattern.source());
+                                        .add(indexPermissions.indexPattern.source(), indexPermissions.rawIndex.isRestrict_to_alias());
                                 }
 
                                 if (indexPermissions.indexPattern.isMatchAll()) {
@@ -423,7 +423,7 @@ public class RoleBasedActionPrivileges extends RuntimeOptimizedActionPrivileges 
                                 for (String action : actionMatcher.iterateMatching(WellKnownActions.INDEX_ACTIONS)) {
                                     rolesToActionToIndexPattern.computeIfAbsent(roleName, k -> new HashMap<>())
                                         .computeIfAbsent(action, indexPatternBuilder)
-                                        .add(indexPermissions.indexPattern.source());
+                                        .add(indexPermissions.indexPattern.source(), indexPermissions.rawIndex.isRestrict_to_alias());
 
                                     if (indexPermissions.indexPattern.isMatchAll()) {
                                         actionToRolesWithWildcardIndexPrivileges.computeIfAbsent(
@@ -435,7 +435,7 @@ public class RoleBasedActionPrivileges extends RuntimeOptimizedActionPrivileges 
 
                                 rolesToActionPatternToIndexPattern.computeIfAbsent(roleName, k -> new HashMap<>())
                                     .computeIfAbsent(actionMatcher, indexPatternBuilder)
-                                    .add(indexPermissions.indexPattern.source());
+                                    .add(indexPermissions.indexPattern.source(), indexPermissions.rawIndex.isRestrict_to_alias());
 
                                 if (actionMatcher != WildcardMatcher.ANY) {
                                     for (String action : actionMatcher.iterateMatching(
@@ -443,7 +443,7 @@ public class RoleBasedActionPrivileges extends RuntimeOptimizedActionPrivileges 
                                     )) {
                                         rolesToExplicitActionToIndexPattern.computeIfAbsent(roleName, k -> new HashMap<>())
                                             .computeIfAbsent(action, indexPatternBuilder)
-                                            .add(indexPermissions.indexPattern.source());
+                                            .add(indexPermissions.indexPattern.source(), indexPermissions.rawIndex.isRestrict_to_alias());
                                     }
                                 }
                             }
@@ -811,7 +811,10 @@ public class RoleBasedActionPrivileges extends RuntimeOptimizedActionPrivileges 
 
                                 indexToRoles.get(index.getName()).add(roleName);
 
-                                if (index instanceof IndexAbstraction.Alias) {
+                                // A "secured view" grant (restrict_to_alias) authorizes access only through the
+                                // alias name itself; it must NOT be inherited by the alias's backing indices. So
+                                // we seed only the alias name above and skip the sub-index seeding below.
+                                if (index instanceof IndexAbstraction.Alias && !indexPermissions.rawIndex.isRestrict_to_alias()) {
                                     // For aliases we additionally add the sub-indices to the privilege map
                                     for (IndexMetadata subIndex : index.getIndices()) {
                                         String subIndexName = subIndex.getIndex().getName();

--- a/src/main/java/org/opensearch/security/securityconf/impl/v7/RoleV7.java
+++ b/src/main/java/org/opensearch/security/securityconf/impl/v7/RoleV7.java
@@ -125,6 +125,13 @@ public class RoleV7 implements Hideable, StaticDefinable {
         private List<String> fls = Collections.emptyList();
         private List<String> masked_fields = Collections.emptyList();
         private List<String> allowed_actions = Collections.emptyList();
+        // When true, a grant on an alias pattern authorizes access only through the alias itself (a "secured
+        // view"); it does NOT confer access to the alias's backing concrete indices when those are requested
+        // directly. Defaults to false, preserving the historical behavior where an alias grant is inherited by
+        // its member indices. Bound explicitly via @JsonProperty so the snake_case name resolves regardless of
+        // the mapper's property-naming strategy (a plain boolean is-getter would otherwise derive a camelCase name).
+        @JsonProperty("restrict_to_alias")
+        private boolean restrict_to_alias = false;
 
         public Index() {
             super();
@@ -170,6 +177,14 @@ public class RoleV7 implements Hideable, StaticDefinable {
             this.allowed_actions = allowed_actions;
         }
 
+        public boolean isRestrict_to_alias() {
+            return restrict_to_alias;
+        }
+
+        public void setRestrict_to_alias(boolean restrict_to_alias) {
+            this.restrict_to_alias = restrict_to_alias;
+        }
+
         @Override
         public String toString() {
             return "Index [index_patterns="
@@ -182,6 +197,8 @@ public class RoleV7 implements Hideable, StaticDefinable {
                 + masked_fields
                 + ", allowed_actions="
                 + allowed_actions
+                + ", restrict_to_alias="
+                + restrict_to_alias
                 + "]";
         }
 
@@ -194,12 +211,13 @@ public class RoleV7 implements Hideable, StaticDefinable {
                 && Objects.equals(dls, index.dls)
                 && Objects.equals(fls, index.fls)
                 && Objects.equals(masked_fields, index.masked_fields)
-                && Objects.equals(allowed_actions, index.allowed_actions);
+                && Objects.equals(allowed_actions, index.allowed_actions)
+                && restrict_to_alias == index.restrict_to_alias;
         }
 
         @Override
         public int hashCode() {
-            return Objects.hash(index_patterns, dls, fls, masked_fields, allowed_actions);
+            return Objects.hash(index_patterns, dls, fls, masked_fields, allowed_actions, restrict_to_alias);
         }
     }
 

--- a/src/main/java/org/opensearch/security/support/ConfigConstants.java
+++ b/src/main/java/org/opensearch/security/support/ConfigConstants.java
@@ -356,6 +356,13 @@ public class ConfigConstants {
     public static final String SECURITY_DLS_MODE = SECURITY_SETTINGS_PREFIX + "dls.mode";
     public static final String SECURITY_DLS_WRITE_BLOCKED = SECURITY_SETTINGS_PREFIX + "dls.write_blocked";
     public static final boolean SECURITY_DLS_WRITE_BLOCKED_ENABLED_DEFAULT = false;
+    // When enabled, DLS applies the role's document filter as a pre-filter: the combined query is
+    // wrapped in constant_score so BM25 statistics reflect only the documents the role can read,
+    // instead of being computed over the whole shard and filtered afterwards. This keeps relevance
+    // scores independent of documents outside the DLS restriction, for the (common) case where
+    // relevance ranking is not required. Opt-in; default false preserves today's behavior.
+    public static final String SECURITY_DLS_PRE_FILTER_SCORING = SECURITY_SETTINGS_PREFIX + "dls.pre_filter_scoring";
+    public static final boolean SECURITY_DLS_PRE_FILTER_SCORING_DEFAULT = false;
     // REST API
     public static final String SECURITY_RESTAPI_ROLES_ENABLED = SECURITY_SETTINGS_PREFIX + "restapi.roles_enabled";
     public static final String SECURITY_RESTAPI_ADMIN_ENABLED = SECURITY_SETTINGS_PREFIX + "restapi.admin.enabled";

--- a/src/main/java/org/opensearch/security/support/SecuritySettings.java
+++ b/src/main/java/org/opensearch/security/support/SecuritySettings.java
@@ -64,6 +64,22 @@ public class SecuritySettings {
         Setting.Property.Sensitive
     );
 
+    public static final Setting<Boolean> DLS_PRE_FILTER_SCORING = Setting.boolSetting(
+        ConfigConstants.SECURITY_DLS_PRE_FILTER_SCORING,
+        ConfigConstants.SECURITY_DLS_PRE_FILTER_SCORING_DEFAULT,
+        Setting.Property.NodeScope,
+        Setting.Property.Dynamic
+    );
+
+    // Registers the existing plugins.security.dls.mode setting (adaptive | lucene_level | filter_level)
+    // so it is accepted by strict settings validation. Previously read via settings.get() without a
+    // registered Setting.
+    public static final Setting<String> DLS_MODE = Setting.simpleString(
+        ConfigConstants.SECURITY_DLS_MODE,
+        "adaptive",
+        Setting.Property.NodeScope
+    );
+
     public static final Setting<Boolean> AUDIT_ENABLED_SETTING = Setting.boolSetting(
         ConfigConstants.SECURITY_AUDIT_ENABLED,
         true,


### PR DESCRIPTION
## What

Adds a **secured view** to the security plugin: a per-grant `restrict_to_alias`
flag on a role's index-permission, composed with the existing DLS pre-filter
scoring bridge.

### 1. `restrict_to_alias` access binding (net-new)

```yaml
index_permissions:
  - index_patterns: ["cardiology_view"]   # an alias
    restrict_to_alias: true
    allowed_actions: ["read"]
```

When set, a grant on an alias authorizes access **only through the alias**; a
direct request for the alias's backing concrete index is denied. Opt-in per
grant, default `false`, so existing alias grants are unchanged.

Closes both alias→index inheritance sites (the evaluator tries the stateful
path first and falls back to the static one, so both are handled):
- `IndexPattern.matches()` — a `restrict_to_alias` pattern no longer walks up
  from a directly-requested backing index to its parent alias/data stream.
- `RoleBasedActionPrivileges` — a `restrict_to_alias` grant seeds only the alias
  name into the precomputed privilege map, not the backing sub-indices; the
  static `IndexPrivileges` merge AND-combines the flag across grants for the same
  `(role, action)` so a normal grant on the same pattern still reaches the
  backing index (union-of-privileges semantics).

Requires the nextgen (v4) privileges evaluator, which preserves the alias name
in the resolved indices; the legacy evaluator resolves aliases to concrete
backing names before the check and cannot distinguish alias access from direct
access.

### 2. DLS pre-filter scoring bridge

When `plugins.security.dls.pre_filter_scoring` is enabled, filter-level and
lucene-level DLS wrap the combined (DLS filter + user query) in a
`constant_score`, so relevance scores reflect only the documents the role can
read. Default off; existing behavior unchanged.

## Testing

- `SecuredViewRestrictToAliasIntegrationTest` (v4, 3/3): view user reads the
  alias, is denied the backing index; a control user with the same grant without
  the flag still reaches the backing index (no regression).
- `IndexPatternTest` unit case on the static matcher.
- `RoleBasedActionPrivilegesTest` (8/8) — no regression.
- `DlsPreFilterScoringIntegrationTest` (3/3) for the scoring bridge, incl.
  `dfs_query_then_fetch`.
